### PR TITLE
feat: Add Vercel rewrite rules for SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
I created a `vercel.json` file with rewrite rules to ensure all requests are directed to `index.html`. This fixes an issue where directly accessing or refreshing a route in a single-page application (SPA) deployed on Vercel would result in a 404 error.

The rewrite rule `{ "source": "/(.*)", "destination": "/index.html" }` allows React Router (or any other client-side router) to handle the routing logic correctly.