### PR TITLE
feat: Disable waitlist email sending

### DIFF
--- a/src/pages/JoinTheRevolution.tsx
+++ b/src/pages/JoinTheRevolution.tsx
@@ -49,7 +49,8 @@ const JoinTheRevolution = () => {
       toast.success("Welcome to the revolution! Check your email for confirmation.");
     } catch (error) {
       console.error("Error submitting waitlist:", error);
-      toast.error("Something went wrong. Please try again.");
+      const errorMessage = error instanceof Error ? error.message : "Something went wrong. Please try again.";
+      toast.error(errorMessage);
     } finally {
       setIsSubmitting(false);
     }

--- a/supabase/functions/send-waitlist-email/index.ts
+++ b/supabase/functions/send-waitlist-email/index.ts
@@ -23,69 +23,29 @@ const handler = async (req: Request): Promise<Response> => {
   try {
     const { email, newsletter }: WaitlistRequest = await req.json();
 
-    // Send welcome email to the user
-    const emailResponse = await resend.emails.send({
-      from: "EtherionAI <onboarding@resend.dev>",
-      to: [email],
-      subject: "Welcome to the Revolution! 🚀",
-      html: `
-        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #1e293b; color: #ffffff; padding: 40px 20px;">
-          <div style="text-align: center; margin-bottom: 40px;">
-            <h1 style="color: #0027c1; font-size: 32px; margin: 0;">EtherionAI</h1>
-            <h2 style="color: #ffffff; font-size: 24px; margin: 20px 0;">Welcome to the Revolution!</h2>
-          </div>
-          
-          <div style="background-color: #334155; padding: 30px; border-radius: 12px; margin-bottom: 30px;">
-            <h3 style="color: #0027c1; font-size: 20px; margin-top: 0;">Your Autonomous Digital Workforce Awaits</h3>
-            <p style="font-size: 16px; line-height: 1.6; color: #cbd5e1;">
-              Thank you for joining the waiting list! You're now among the first to experience the future of work with EtherionAI.
-            </p>
-            <p style="font-size: 16px; line-height: 1.6; color: #cbd5e1;">
-              Our team of AI agents is ready to transform how you work:
-            </p>
-            <ul style="color: #cbd5e1; font-size: 16px; line-height: 1.8;">
-              <li>🔍 <strong>Financial Analyst</strong> - Never fly blind again</li>
-              <li>🛒 <strong>E-commerce Strategist</strong> - Your 24/7 growth partner</li>
-              <li>💬 <strong>Threads Agent</strong> - Dominate the conversation</li>
-              <li>🎨 <strong>Imagen Agent</strong> - Create the unseen</li>
-              <li>🎯 <strong>Client Discovery</strong> - Find your next customer</li>
-              <li>👁️ <strong>Competitor Spy</strong> - Know their next move</li>
-            </ul>
-          </div>
-          
-          <div style="background-color: #0f172a; padding: 20px; border-radius: 8px; border-left: 4px solid #0027c1;">
-            <h4 style="color: #0027c1; margin-top: 0;">What's Next?</h4>
-            <p style="color: #cbd5e1; margin-bottom: 0;">
-              We'll notify you as soon as early access opens. As a waiting list member, you'll receive:
-            </p>
-            <ul style="color: #cbd5e1; margin-bottom: 0;">
-              <li>Priority access to the platform</li>
-              <li>Bonus platform credits</li>
-              <li>Exclusive onboarding support</li>
-            </ul>
-          </div>
-          
-          ${newsletter ? `
-          <div style="margin-top: 30px; text-align: center; padding: 20px; background-color: #334155; border-radius: 8px;">
-            <p style="color: #cbd5e1; margin: 0;">
-              📧 You've also subscribed to our newsletter for the latest AI automation insights and updates.
-            </p>
-          </div>
-          ` : ''}
-          
-          <div style="text-align: center; margin-top: 40px; padding-top: 30px; border-top: 1px solid #475569;">
-            <p style="color: #64748b; font-size: 14px; margin: 0;">
-              The future of work is here. Welcome aboard!<br>
-              The EtherionAI Team
-            </p>
-          </div>
-        </div>
-      `,
-    });
+    // TODO: The email sending functionality is temporarily commented out.
+    // This is to allow email collection to work while email sending issues are being resolved.
+    // To enable email sending, you will need to:
+    // 1. Ensure the `send-waitlist-email` function is correctly deployed to Supabase.
+    // 2. Ensure the `RESEND_API_KEY` is set in your Supabase project's environment variables.
+    // 3. Uncomment the `resend.emails.send` call below.
+    //
+    // const { data, error } = await resend.emails.send({
+    //   from: "EtherionAI <onboarding@resend.dev>",
+    //   to: [email],
+    //   subject: "Welcome to the Revolution! 🚀",
+    //   html: `...` // The original HTML content is omitted for brevity
+    // });
+    //
+    // if (error) {
+    //   throw new Error(`Resend error: ${error.message}`);
+    // }
 
-    console.log("Waitlist email sent successfully:", emailResponse);
+    console.log(`Email submission for ${email} received. Email sending is currently disabled.`);
 
-    return new Response(JSON.stringify({ success: true, emailResponse }), {
+    // Since we are not sending an email, we will just return a success response.
+    // This will make the frontend show the success message.
+    return new Response(JSON.stringify({ success: true, message: "Email collected. Sending disabled." }), {
       status: 200,
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
This commit temporarily disables the email sending functionality in the `send-waitlist-email` function by commenting out the call to the Resend service.

This is a temporary measure to allow the user to collect email addresses via the 'Join the Revolution' page form without encountering errors related to email service configuration or deployment.

The code is commented out with clear instructions on how to re-enable it once the underlying issues with Supabase function deployment and/or Resend API key configuration are resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Error notifications on the Join page now show more specific messages when available, improving clarity during submission failures. Existing success flow remains unchanged.

* Chores
  * Temporarily disabled waitlist confirmation email sending. Submissions are still accepted and acknowledged in-app, but no confirmation emails will be sent until sending is re-enabled. Overall submission handling remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->