### PR TITLE
feat: improve error handling for waitlist form

### DIFF
--- a/src/pages/JoinTheRevolution.tsx
+++ b/src/pages/JoinTheRevolution.tsx
@@ -9,6 +9,11 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent } from "@/components/ui/card";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
+import {
+  FunctionsHttpError,
+  FunctionsRelayError,
+  FunctionsFetchError,
+} from "@supabase/supabase-js";
 
 // Import all the agent illustrations
 import heroNetwork from "@/assets/business-leaders-scaled.jpg";
@@ -46,10 +51,29 @@ const JoinTheRevolution = () => {
       if (error) throw error;
 
       setIsSubmitted(true);
-      toast.success("Welcome to the revolution! Check your email for confirmation.");
-    } catch (error) {
+      toast.success(
+        "Welcome to the revolution! Check your email for confirmation."
+      );
+    } catch (error: any) {
       console.error("Error submitting waitlist:", error);
-      toast.error("Something went wrong. Please try again.");
+      if (error instanceof FunctionsHttpError) {
+        try {
+          const errorMessage = await error.context.json();
+          if (errorMessage && errorMessage.error) {
+            toast.error(errorMessage.error);
+          } else {
+            toast.error("An unexpected error occurred. Please try again.");
+          }
+        } catch (e) {
+          toast.error("An unexpected error occurred. Please try again.");
+        }
+      } else if (error instanceof FunctionsRelayError) {
+        toast.error("Network error. Please check your connection and try again.");
+      } else if (error instanceof FunctionsFetchError) {
+        toast.error("Could not connect to the server. Please try again later.");
+      } else {
+        toast.error("An unexpected error occurred. Please try again.");
+      }
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
This commit improves the error handling for the waitlist form on the 'Join the Revolution' page.

- Imports specific Supabase error types (`FunctionsHttpError`, `FunctionsRelayError`, `FunctionsFetchError`).
- Updates the `handleSubmit` function to catch these specific errors.
- Displays more informative error messages to the user based on the error type.
- This will help in debugging the underlying issue, which is likely a missing `RESEND_API_KEY` in the Supabase environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error feedback on the Join the Revolution form: clear messages for server errors, network issues, and connection failures.
  * More robust handling prevents confusing generic errors and ensures appropriate user guidance.
  * Success flow unchanged; submission state resets reliably after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->